### PR TITLE
retry logic to save_current_output_image

### DIFF
--- a/scripts/video_loopback.py
+++ b/scripts/video_loopback.py
@@ -183,7 +183,8 @@ class TemporalImageBlender:
                     img.putalpha(self.current_mask())
                 img.save(path)
                 break 
-            except FileNotFoundError:
+            except (OSError, FileNotFoundError) as e:
+                # Transport endpoint is not connected or FileNotFoundError
                 if i < max_retries - 1:  # wait for a while unless this is the last try
                     time.sleep(retry_interval)
                 else:

--- a/scripts/video_loopback.py
+++ b/scripts/video_loopback.py
@@ -1,5 +1,6 @@
 import gradio as gr
 import modules
+import time
 from modules import processing, shared
 from modules.processing import Processed
 
@@ -174,10 +175,19 @@ class TemporalImageBlender:
         return output_img
 
     def save_current_output_image(self, path, img: Image.Image):
-        if self.use_mask and not self.mask_dir:
-            img.putalpha(self.current_mask())
-        img.save(path)
-
+        max_retries = 3
+        retry_interval = 5  # seconds
+        for i in range(max_retries):
+            try:
+                if self.use_mask and not self.mask_dir:
+                    img.putalpha(self.current_mask())
+                img.save(path)
+                break 
+            except FileNotFoundError:
+                if i < max_retries - 1:  # wait for a while unless this is the last try
+                    time.sleep(retry_interval)
+                else:
+                    raise 
 
 class Script(modules.scripts.Script):
     def title(self):

--- a/scripts/video_loopback.py
+++ b/scripts/video_loopback.py
@@ -185,6 +185,7 @@ class TemporalImageBlender:
                 break 
             except (OSError, FileNotFoundError) as e:
                 # Transport endpoint is not connected or FileNotFoundError
+                print(f"Exception occurred: {type(e).__name__} - {str(e)}")
                 if i < max_retries - 1:  # wait for a while unless this is the last try
                     time.sleep(retry_interval)
                 else:


### PR DESCRIPTION
This commit addresses the FileNotFoundError issue in the save_current_output_image method. This error sometimes happen especially on google colab in the long session.

Implement retry logic using a try-except block to handle FileNotFoundError when saving the image. The method will retry saving the image up to a specified maximum number of times with a specified time interval between retries.